### PR TITLE
Respect "do not track"

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "video.js": "^5.0.0",
     "videojs-font": "^1.0.0",
     "videojs-ie8": "^1.0.0",
-    "videojs-swf": "^4.7.0"
+    "videojs-swf": "^4.7.0",
     "videojs-vtt.js": "^0.12.3"
   },
   "devDependencies": {

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -10,6 +10,7 @@
   // Skip analytics if preferred
   if (!w || w.HELP_IMPROVE_VIDEOJS === false) return;
 
+  // Respect Do Not Track in its various forms
   if (n && n.doNotTrack && n.doNotTrack === '1') return;
   if (n && n.msDoNotTrack && n.msDoNotTrack === '1') return;
   if (w.doNotTrack && w.doNotTrack === '1') return;

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -10,6 +10,10 @@
   // Skip analytics if preferred
   if (!w || w.HELP_IMPROVE_VIDEOJS === false) return;
 
+  if (n && n.doNotTrack && n.doNotTrack === '1') return;
+  if (n && n.msDoNotTrack && n.msDoNotTrack === '1') return;
+  if (w.doNotTrack && w.doNotTrack === '1') return;
+
   // Track 1 in 100 player loads for brower and device stats.
   // Also Google Analytics has a limit of 10 million hits per month.
   // The Video.js CDN goes over this (by a lot) and they've asked us to stop.


### PR DESCRIPTION
If the browser user preferences have "do not track" enabled, don't use the Google Analytics pixel